### PR TITLE
Fix: Remove "Copier un plan" button and improve sync modal error hand…

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -25,7 +25,6 @@ export default function DashboardPage() {
   const {
     monthlyPlans,
     addMonthlyPlan,
-    copyMonthlyPlan,
     setCurrentMonth,
     deleteMonthlyPlan,
     importMonthlyPlanFromData,
@@ -38,7 +37,6 @@ export default function DashboardPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importError, setImportError] = useState<string | null>(null);
   const [importSuccess, setImportSuccess] = useState<string | null>(null);
-  const [showCopyModal, setShowCopyModal] = useState(false);
   const [showBetaWarning, setShowBetaWarning] = useState(true);
   const [showMigrationModal, setShowMigrationModal] = useState(false);
   const [showMigrationBanner, setShowMigrationBanner] = useState(true);
@@ -110,15 +108,6 @@ export default function DashboardPage() {
     const now = new Date();
     const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
     addMonthlyPlan(month);
-    router.push('/onboarding');
-  };
-
-  const handleCopyPlan = (sourceId: string) => {
-    const now = new Date();
-    const newMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-
-    copyMonthlyPlan(sourceId, newMonth);
-    setShowCopyModal(false);
     router.push('/onboarding');
   };
 
@@ -428,39 +417,21 @@ export default function DashboardPage() {
             </button>
 
             {monthlyPlans.length > 0 && (
-              <>
-                <button
-                  onClick={() => setShowCopyModal(true)}
-                  className="px-4 md:px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors flex items-center justify-center gap-2 min-h-[44px] text-sm md:text-base"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                    />
-                  </svg>
-                  <span className="hidden sm:inline">Copier un plan</span>
-                  <span className="sm:hidden">Copier</span>
-                </button>
-
-                <button
-                  onClick={handleExportAll}
-                  className="px-4 md:px-6 py-3 bg-purple-600 text-white rounded-lg font-medium hover:bg-purple-700 transition-colors flex items-center justify-center gap-2 min-h-[44px] text-sm md:text-base"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-                    />
-                  </svg>
-                  <span className="hidden sm:inline">Exporter tous</span>
-                  <span className="sm:hidden">Exporter</span>
-                </button>
-              </>
+              <button
+                onClick={handleExportAll}
+                className="px-4 md:px-6 py-3 bg-purple-600 text-white rounded-lg font-medium hover:bg-purple-700 transition-colors flex items-center justify-center gap-2 min-h-[44px] text-sm md:text-base"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                  />
+                </svg>
+                <span className="hidden sm:inline">Exporter tous</span>
+                <span className="sm:hidden">Exporter</span>
+              </button>
             )}
 
             <button
@@ -637,68 +608,6 @@ export default function DashboardPage() {
           )}
         </div>
       </div>
-
-      {/* Modal de copie de plan */}
-      {showCopyModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-y-auto">
-            <div className="p-4 md:p-6 border-b border-slate-200 dark:border-slate-700">
-              <h2 className="text-xl md:text-2xl font-bold text-slate-800 dark:text-slate-100">
-                Copier un plan existant
-              </h2>
-              <p className="text-sm md:text-base text-slate-600 dark:text-slate-400 mt-1">
-                Sélectionnez le plan que vous souhaitez copier
-              </p>
-            </div>
-
-            <div className="p-4 md:p-6 space-y-2 md:space-y-3">
-              {sortedPlans.map((plan) => {
-                const monthDate = new Date(plan.month + '-01');
-                const monthLabel = monthDate.toLocaleDateString('fr-FR', {
-                  month: 'long',
-                  year: 'numeric',
-                });
-                const summary = getPlanSummary(plan);
-
-                return (
-                  <button
-                    key={plan.id}
-                    onClick={() => handleCopyPlan(plan.id)}
-                    className="w-full text-left p-3 md:p-4 bg-slate-50 dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg border border-slate-200 dark:border-slate-600 transition-colors min-h-[44px]"
-                  >
-                    <h3 className="text-base md:text-lg font-semibold text-slate-800 dark:text-slate-100 capitalize mb-2">
-                      {monthLabel}
-                    </h3>
-                    <div className="grid grid-cols-2 gap-2 text-xs md:text-sm">
-                      <div>
-                        <span className="text-slate-500 dark:text-slate-400">Revenus: </span>
-                        <span className="font-semibold text-green-600 dark:text-green-400">
-                          {formatCurrency(summary.totalIncome)}
-                        </span>
-                      </div>
-                      <div>
-                        <span className="text-slate-500 dark:text-slate-400">Dépenses: </span>
-                        <span className="font-semibold text-red-600 dark:text-red-400">
-                          {formatCurrency(summary.totalFixedExpenses)}
-                        </span>
-                      </div>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-
-            <div className="p-4 md:p-6 border-t border-slate-200 dark:border-slate-700">
-              <button
-                onClick={() => setShowCopyModal(false)}
-                className="w-full px-4 md:px-6 py-3 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200 rounded-lg font-medium hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors min-h-[44px]"
-              >
-                Annuler
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Modal de migration des données */}
       <LocalDataMigrationModal


### PR DESCRIPTION
…ling

- Removed "Copier un plan" button and associated modal/state/handlers as requested
- Added comprehensive error handling to SyncManagementModal to prevent white screen errors
- Added null checks for all sync-related functions (refreshPlansSyncStatus, getCloudPlansMetadata, etc.)
- Added optional chaining for planSyncStatus accesses to prevent undefined errors
- Improved error messages to be more user-friendly
- Fixed potential crashes when sync functions are unavailable or user is not connected

This ensures the sync management modal gracefully handles errors instead of showing a blank white screen.